### PR TITLE
Replace specific mention of LDAP

### DIFF
--- a/requirements.tex
+++ b/requirements.tex
@@ -16,7 +16,7 @@ Figure \ref{fig:idac-topology} shows a  topology for a set of interconnected IDA
 \end{figure}
 
 \subsection{Authentication and Access}\label{sec:auth}
-Any DAC will have to support authentication according to \RO access rules. This may imply interfacing with the \RO LDAP. In addition any user with access rights should be allowed access tot he IDAC.
+Any DAC will have to support authentication according to \RO access rules. This may imply delegating access control to a \RO authorization service. In addition any user with access rights should be allowed access tot he IDAC.
 
 \subsection{Required Resources} \label{sec:resources}
 Institutions or organizations wishing to set up independent data access centres will be expected to have


### PR DESCRIPTION
It's unlikely that we'll have a public LDAP service, so replace the
mention of Rubin Observatory LDAP in section 3.2 with a more general
reference to a Rubin Observatory authorization service.